### PR TITLE
Add missing Rating DTO and refine timeslot handling

### DIFF
--- a/Client/Services/ApiService.cs
+++ b/Client/Services/ApiService.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net.Http.Json;
-using lunchapp.Models;
-using lunchapp.Shared.DTOs;
+using LunchApp.Shared.Models;
+using LunchApp.Shared.DTOs;
 
 namespace LunchApp.Client.Services
 {

--- a/Client/Services/AuthService.cs
+++ b/Client/Services/AuthService.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net.Http.Json;
-using lunchapp.Shared.DTOs;
+using LunchApp.Shared.DTOs;
 
 namespace LunchApp.Client.Services
 {

--- a/Server/Controllers/AccountController.cs
+++ b/Server/Controllers/AccountController.cs
@@ -1,5 +1,4 @@
-﻿using lunchapp.Shared.DTOs;
-using LunchApp.Shared.DTOs;
+﻿using LunchApp.Shared.DTOs;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 

--- a/Server/Controllers/AdminController.cs
+++ b/Server/Controllers/AdminController.cs
@@ -1,4 +1,4 @@
-﻿using lunchapp.Shared.DTOs;
+﻿using LunchApp.Shared.DTOs;
 using LunchApp.Server.Data;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/Server/Controllers/OrderController.cs
+++ b/Server/Controllers/OrderController.cs
@@ -1,4 +1,4 @@
-﻿using lunchapp.Shared.DTOs;
+﻿using LunchApp.Shared.DTOs;
 using LunchApp.Server.Data; 
 using Microsoft.AspNetCore.Mvc;
 

--- a/Server/Controllers/TimeSlotController.cs
+++ b/Server/Controllers/TimeSlotController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using LunchApp.Server.Data;
+using LunchApp.Shared.DTOs;
 
 namespace LunchApp.Server.Controllers
 {

--- a/Server/Data/AppDbContext.cs
+++ b/Server/Data/AppDbContext.cs
@@ -1,5 +1,4 @@
-﻿using lunchapp.Models;
-using LunchApp.Shared.Models;
+﻿using LunchApp.Shared.Models;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -1,4 +1,3 @@
-using lunchapp.Data;
 using LunchApp.Server.Data;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;

--- a/Shared/DTOs/RatingDto.cs
+++ b/Shared/DTOs/RatingDto.cs
@@ -1,0 +1,10 @@
+﻿namespace LunchApp.Shared.DTOs
+{
+    public class RatingDto
+    {
+        public int UserId { get; set; }
+        public int DishId { get; set; }
+        public int Stars { get; set; }
+        public string Comment { get; set; }
+    }
+}

--- a/Shared/Models/Order.cs
+++ b/Shared/Models/Order.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using lunchapp.Models;
 
 namespace LunchApp.Shared.Models
 {

--- a/Shared/Models/TimeSlot.cs
+++ b/Shared/Models/TimeSlot.cs
@@ -1,4 +1,4 @@
-﻿namespace LunchApp.Shared.DTOs
+﻿namespace LunchApp.Shared.Models
 {
     public class TimeSlot
     {


### PR DESCRIPTION
## Summary
- fix mismatched namespace for `TimeSlot` model
- import DTO namespace in `TimeSlotController`
- add new `RatingDto` class used by `RatingController`

## Testing
- `dotnet build LunchApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d8154ca483218ed984c56fe0d1db