### PR TITLE
Fix missing AddSwaggerGen extension

### DIFF
--- a/Server/LunchApp.Server.csproj
+++ b/Server/LunchApp.Server.csproj
@@ -19,6 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- reference Swashbuckle.AspNetCore in the server project

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846dd2ff5a88321981d9a0400c24ced