### PR TITLE
Fix markup for single-statement razor if blocks

### DIFF
--- a/Client/Pages/Menu.razor
+++ b/Client/Pages/Menu.razor
@@ -3,7 +3,10 @@
 
 <h3>Today's Menu</h3>
 
-@if (menu == null) <p>Loading...</p>
+@if (menu == null)
+{
+    <p>Loading...</p>
+}
 else
 {
     foreach (var dish in menu)

--- a/Client/Pages/Order.razor
+++ b/Client/Pages/Order.razor
@@ -3,7 +3,10 @@
 
 <h3>Place Order</h3>
 
-@if (timeSlots == null) <p>Loading slots...</p>
+@if (timeSlots == null)
+{
+    <p>Loading slots...</p>
+}
 else
 {
     <p>Select a pickup time:</p>


### PR DESCRIPTION
## Summary
- wrap markup in braces for `@if` blocks in `Menu.razor` and `Order.razor`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846df626f3c8321b10204002cb5ac21