### PR TITLE
Fix order item include property

### DIFF
--- a/Server/Controllers/AdminController.cs
+++ b/Server/Controllers/AdminController.cs
@@ -49,7 +49,7 @@ namespace LunchApp.Server.Controllers
         {
             var orders = await _context.Orders
                 .Where(o => o.Date == date)
-                .Include(o => o.OrderItems)
+                .Include(o => o.Items)
                     .ThenInclude(i => i.Dish)
                 .ToListAsync();
             return Ok(orders);


### PR DESCRIPTION
## Summary
- fix admin order retrieval by using `Items` navigation property

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846e672d664832184fabe5330a0ac62