### PR TITLE
Fix TimeSlotController query

### DIFF
--- a/Server/Controllers/TimeSlotController.cs
+++ b/Server/Controllers/TimeSlotController.cs
@@ -16,9 +16,14 @@ namespace LunchApp.Server.Controllers
         public async Task<IActionResult> GetSlots([FromQuery] DateTime date)
         {
             var slots = await _context.Orders
-                .Where(o => o.Date == date)
-                .GroupBy(o => o.PickupTime)
-                .Select(g => new TimeSlotDto { Time = g.Key, Count = g.Count() })
+                .Where(o => o.OrderDate.Date == date.Date)
+                .Include(o => o.Slot)
+                .GroupBy(o => new { o.Slot.StartTime, o.Slot.EndTime })
+                .Select(g => new TimeSlotDto
+                {
+                    Time = $"{g.Key.StartTime:hh\\:mm}-{g.Key.EndTime:hh\\:mm}",
+                    Count = g.Count()
+                })
                 .ToListAsync();
             return Ok(slots);
         }


### PR DESCRIPTION
## Summary
- fix LINQ query in TimeSlotController to use OrderDate and Slot times

## Testing
- `dotnet build OfficeCafeApp.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481a1bfd308321bb3f4d9466080160