### PR TITLE
Fix OrderDto missing properties

### DIFF
--- a/Server/DTOs/OrderDto.cs
+++ b/Server/DTOs/OrderDto.cs
@@ -1,10 +1,20 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using OfficeCafeApp.API.DTOs;
 
 namespace LunchApp.Shared.DTOs
 {
     public class OrderDto
     {
+        // Properties returned when retrieving an order
+        public Guid Id { get; set; }
+        public DateTime OrderDate { get; set; }
+        public string Status { get; set; }
+        public string QRCode { get; set; }
+        public string Slot { get; set; }
+        public List<OrderItemDto> Items { get; set; }
+
+        // Properties used when creating an order
         public int UserId { get; set; }
         public List<int> DishIds { get; set; }
         public string PickupTime { get; set; }


### PR DESCRIPTION
## Summary
- rework `OrderDto` to include fields used by the API

## Testing
- `dotnet build OfficeCafeApp.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481b2eadd083219ecbf50353f19004