### PR TITLE
Fix missing DishName property in OrderItemDto

### DIFF
--- a/Server/DTOs/OrderCreateDto.cs
+++ b/Server/DTOs/OrderCreateDto.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace OfficeCafeApp.API.DTOs
 {
@@ -11,6 +11,8 @@ namespace OfficeCafeApp.API.DTOs
     public class OrderItemDto
     {
         public int DishId { get; set; }
+        public string DishName { get; set; }
+        public decimal Price { get; set; }
         public int Quantity { get; set; } = 1;
     }
 }


### PR DESCRIPTION
## Summary
- expand `OrderItemDto` with `DishName` and `Price` fields used when fetching orders

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481c542f808321a17a37a6e70fdf78