### PR TITLE
Fix missing namespace error by replacing server storage

### DIFF
--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -10,6 +10,7 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 builder.Services.AddAuthorizationCore();
+builder.Services.AddScoped<TokenStorageService>();
 builder.Services.AddScoped<JwtAuthStateProvider>();
 builder.Services.AddScoped<AuthenticationStateProvider>(sp => sp.GetRequiredService<JwtAuthStateProvider>());
 builder.Services.AddScoped<AuthService>();

--- a/Client/Services/TokenStorageService.cs
+++ b/Client/Services/TokenStorageService.cs
@@ -1,0 +1,24 @@
+using Microsoft.JSInterop;
+
+namespace LunchApp.Client.Services
+{
+    public class TokenStorageService
+    {
+        private readonly IJSRuntime _js;
+        private const string TokenKey = "authToken";
+
+        public TokenStorageService(IJSRuntime js)
+        {
+            _js = js;
+        }
+
+        public ValueTask<string?> GetTokenAsync()
+            => _js.InvokeAsync<string?>("localStorage.getItem", TokenKey);
+
+        public ValueTask SetTokenAsync(string token)
+            => _js.InvokeVoidAsync("localStorage.setItem", TokenKey, token);
+
+        public ValueTask RemoveTokenAsync()
+            => _js.InvokeVoidAsync("localStorage.removeItem", TokenKey);
+    }
+}


### PR DESCRIPTION
## Summary
- remove dependency on `Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage`
- implement a JS-based `TokenStorageService` for WebAssembly
- update `JwtAuthStateProvider` and program registration

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848290ca49c8321941baafbae652717