### PR TITLE
Resolve Dish class ambiguity

### DIFF
--- a/Server/Data/AppDbContext.cs
+++ b/Server/Data/AppDbContext.cs
@@ -1,4 +1,3 @@
-﻿using LunchApp.Shared.Models;
 using Microsoft.EntityFrameworkCore;
 using OfficeCafeApp.API.Models;
 
@@ -13,7 +12,7 @@ namespace OfficeCafeApp.API.Data
         public DbSet<Slot> Slots { get; set; }
         public DbSet<Order> Orders { get; set; }
         public DbSet<OrderItem> OrderItems { get; set; }
-        public DbSet<Rating> Ratings { get; set; }
+        public DbSet<LunchApp.Shared.Models.Rating> Ratings { get; set; }
         public DbSet<MenuSchedule> MenuSchedules { get; set; } 
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/Server/Models/Order.cs
+++ b/Server/Models/Order.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using LunchApp.Shared.Models;
 
 namespace OfficeCafeApp.API.Models
 {


### PR DESCRIPTION
## Summary
- remove unneeded Shared model usage from Order
- avoid importing all Shared models in AppDbContext
- fully qualify Rating DbSet to prevent `Dish` ambiguity

## Testing
- `dotnet build OfficeCafeApp.sln -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482a3190d48321a032407361654843