### PR TITLE
Fix root namespace for client project

### DIFF
--- a/Client/LunchApp.Frontend.csproj
+++ b/Client/LunchApp.Frontend.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>LunchApp.Client</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- set `RootNamespace` in `LunchApp.Frontend.csproj` to `LunchApp.Client`

## Testing
- `dotnet build OfficeCafeApp.sln -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68482b1172b88321b73c3ecba9df4733