### PR TITLE
Fix async rendering error in NavMenu

### DIFF
--- a/Client/App.razor
+++ b/Client/App.razor
@@ -1,13 +1,15 @@
 @using Microsoft.AspNetCore.Components.Routing
 
-<Router AppAssembly="typeof(App).Assembly">
-    <Found Context="routeData">
-        <AuthorizeRouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)" />
-        <FocusOnNavigate RouteData="routeData" Selector="h1" />
-    </Found>
-    <NotFound>
-        <LayoutView Layout="typeof(MainLayout)">
-            <p>Sorry, theres nothing here.</p>
-        </LayoutView>
-    </NotFound>
-</Router>
+<CascadingAuthenticationState>
+    <Router AppAssembly="@typeof(App).Assembly">
+        <Found Context="routeData">
+            <AuthorizeRouteView RouteData="routeData" DefaultLayout="@typeof(MainLayout)" />
+            <FocusOnNavigate RouteData="routeData" Selector="h1" />
+        </Found>
+        <NotFound>
+            <LayoutView Layout="@typeof(MainLayout)">
+                <p>Sorry, theres nothing here.</p>
+            </LayoutView>
+        </NotFound>
+    </Router>
+</CascadingAuthenticationState>

--- a/Client/Shared/NavMenu.razor
+++ b/Client/Shared/NavMenu.razor
@@ -1,4 +1,3 @@
-@inject AuthenticationStateProvider AuthState
 @inject AuthService Auth
 
 <nav>
@@ -6,15 +5,15 @@
         <li><NavLink href="/" Match="NavLinkMatch.All">Home</NavLink></li>
         <li><NavLink href="/menu">Menu</NavLink></li>
         <li><NavLink href="/order">Order</NavLink></li>
-        @if ((await AuthState.GetAuthenticationStateAsync()).User.Identity?.IsAuthenticated ?? false)
-        {
-            <li><button @onclick="Logout">Logout</button></li>
-        }
-        else
-        {
-            <li><NavLink href="/login">Login</NavLink></li>
-            <li><NavLink href="/register">Register</NavLink></li>
-        }
+        <AuthorizeView>
+            <Authorized>
+                <li><button @onclick="Logout">Logout</button></li>
+            </Authorized>
+            <NotAuthorized>
+                <li><NavLink href="/login">Login</NavLink></li>
+                <li><NavLink href="/register">Register</NavLink></li>
+            </NotAuthorized>
+        </AuthorizeView>
     </ul>
 </nav>
 


### PR DESCRIPTION
## Summary
- avoid using `await` directly in NavMenu markup by using `AuthorizeView`
- wrap the router in `CascadingAuthenticationState` and fix `App.razor` bindings

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482c5803c883219f15a2971f13c10d