### PR TITLE
Add error handling for menu page

### DIFF
--- a/Client/Pages/Menu.razor
+++ b/Client/Pages/Menu.razor
@@ -3,7 +3,11 @@
 
 <h3>Today's Menu</h3>
 
-@if (menu == null)
+@if (!string.IsNullOrEmpty(loadError))
+{
+    <p style="color:red">@loadError</p>
+}
+else if (menu == null)
 {
     <p>Loading...</p>
 }
@@ -20,8 +24,16 @@ else
 
 @code {
     List<Dish> menu;
+    string loadError;
     protected override async Task OnInitializedAsync()
     {
-        menu = await Api.GetTodayMenu();
+        try
+        {
+            menu = await Api.GetTodayMenu();
+        }
+        catch
+        {
+            loadError = "Failed to load menu.";
+        }
     }
 }


### PR DESCRIPTION
## Summary
- wrap API call in Menu.razor with try/catch
- show error message if menu fails to load

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848304fe55c83219ee935b786e9bed5