### PR TITLE
Fix Blazor client startup

### DIFF
--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -38,6 +38,8 @@ builder.Services.AddAuthorization(options =>
 });
 
 builder.Services.AddControllers();
+builder.Services.AddControllersWithViews();
+builder.Services.AddRazorPages();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
@@ -60,7 +62,16 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+app.UseBlazorFrameworkFiles();
+app.UseStaticFiles();
+
+app.UseRouting();
+
 app.UseAuthentication();
 app.UseAuthorization();
+
+app.MapRazorPages();
 app.MapControllers();
+app.MapFallbackToFile("index.html");
+
 app.Run();


### PR DESCRIPTION
## Summary
- serve the Blazor WebAssembly client through the API project so the browser can load `_framework` files

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848332eae8883219a6db735f789b1f7