### PR TITLE
Fix missing client assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# LunchApp
+
+This repository contains an ASP.NET Core Web API backend and a Blazor WebAssembly client.
+
+## Requirements
+- .NET 8 SDK
+- A SQL Server instance accessible by the connection string in `Server/appsettings.json`.
+
+## Running the app
+From the repository root, start the backend API and the Blazor client in separate terminals:
+
+```bash
+# Start the Web API
+ dotnet run --project Server/OfficeCafeApp.API.csproj
+
+# Start the Blazor WebAssembly client
+ dotnet run --project Client/LunchApp.Frontend.csproj
+```
+
+Browse to `http://localhost:5025/login` to access the application.

--- a/Server/OfficeCafeApp.API.csproj
+++ b/Server/OfficeCafeApp.API.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Shared\LunchApp.Shared.csproj" />
+    <ProjectReference Include="..\Client\LunchApp.Frontend.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- reference the Blazor client project from the API project so static assets are served
- add a simple README with instructions to run the API and Blazor app

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68483540dc4c8321aa394d44b3bccc2e