### PR TITLE
UI improvements

### DIFF
--- a/Client/Pages/Login.razor
+++ b/Client/Pages/Login.razor
@@ -11,10 +11,13 @@
         <InputText class="form-control" @bind-Value="loginModel.Password" type="password" placeholder="Password" />
     </div>
     <button class="btn btn-primary w-100" type="submit">Login</button>
+    <div class="text-center mt-2">
+        <a href="/register">Need an account? Register</a>
+    </div>
 </EditForm>
 @if (!string.IsNullOrEmpty(error))
 {
-    <p style="color:red">@error</p>
+    <div class="alert alert-danger mt-3" role="alert">@error</div>
 }
 
 @code {

--- a/Client/Pages/Order.razor
+++ b/Client/Pages/Order.razor
@@ -15,7 +15,7 @@ else
             <ul class="list-group list-group-flush">
                 @foreach (var slot in timeSlots)
                 {
-                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <li class="list-group-item d-flex justify-content-between align-items-center @(slot.Time == selectedTime ? "active" : null)">
                         <span>@slot.Time (@slot.Count orders)</span>
                         <button class="btn btn-sm btn-outline-primary" @onclick="() => SelectTime(slot.Time)">Select</button>
                     </li>
@@ -28,6 +28,10 @@ else
                     <button class="btn btn-success" @onclick="SubmitOrder">Submit Order</button>
                 </div>
             }
+            @if (!string.IsNullOrEmpty(orderMessage))
+            {
+                <div class="alert alert-success mt-3" role="alert">@orderMessage</div>
+            }
         </div>
     </div>
 }
@@ -35,12 +39,17 @@ else
 @code {
     List<TimeSlot> timeSlots;
     string selectedTime;
+    string orderMessage;
 
     protected override async Task OnInitializedAsync()
     {
         timeSlots = await Api.GetTimeSlots(DateTime.Today);
     }
-    void SelectTime(string time) => selectedTime = time;
+    void SelectTime(string time)
+    {
+        selectedTime = time;
+        orderMessage = string.Empty;
+    }
     async Task SubmitOrder()
     {
         var dto = new OrderCreateDto
@@ -52,5 +61,6 @@ else
             }
         };
         await Api.PlaceOrder(dto);
+        orderMessage = "Order placed!";
     }
 }

--- a/Client/Pages/Register.razor
+++ b/Client/Pages/Register.razor
@@ -14,10 +14,13 @@
         <InputText class="form-control" @bind-Value="regModel.ConfirmPassword" type="password" placeholder="Confirm Password" />
     </div>
     <button class="btn btn-primary w-100" type="submit">Register</button>
+    <div class="text-center mt-2">
+        <a href="/login">Already have an account? Login</a>
+    </div>
 </EditForm>
 @if (!string.IsNullOrEmpty(error))
 {
-    <p style="color:red">@error</p>
+    <div class="alert alert-danger mt-3" role="alert">@error</div>
 }
 
 @code {

--- a/Client/Shared/Footer.razor
+++ b/Client/Shared/Footer.razor
@@ -1,0 +1,3 @@
+<footer class="bg-light text-center mt-5 py-3 border-top">
+    <span class="text-muted">© 2024 LunchApp</span>
+</footer>

--- a/Client/Shared/MainLayout.razor
+++ b/Client/Shared/MainLayout.razor
@@ -1,7 +1,8 @@
-﻿@inherits LayoutComponentBase
+@inherits LayoutComponentBase
 <div class="page">
     <NavMenu />
     <main class="container mt-4">
         @Body
     </main>
+    <Footer />
 </div>

--- a/Client/wwwroot/css/app.css
+++ b/Client/wwwroot/css/app.css
@@ -31,3 +31,7 @@ h1:focus {
         content: "An error has occurred."
     }
 
+
+/* highlight selected order time slot */
+.list-group-item.active { background-color: #0d6efd; color: #fff; }
+


### PR DESCRIPTION
## Summary
- add a simple footer component and include it in the layout
- show nicer error alerts and links between Login/Register pages
- highlight chosen time slot when placing an order and display order confirmation
- style active slot items

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848486afd6c8321beb4c24c4de231c0