### PR TITLE
Fix base href for local static page

### DIFF
--- a/Client/wwwroot/index.html
+++ b/Client/wwwroot/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8" />
     <title>LunchApp</title>
-    <base href="/" />
+    <base href="./" />
     <link href="css/app.css" rel="stylesheet" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQJ0Jy2G2efWgqlaHwN5mZ9O7mL1Y9E6MBFbS6FONxqhPp/9cqE+76PVC" crossorigin="anonymous">
     


### PR DESCRIPTION
## Summary
- update index.html so relative paths work when opened directly

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68492c4c33208321a1fbdf3756feb6f3