### PR TITLE
Fix compile errors

### DIFF
--- a/Server/Models/Slot.cs
+++ b/Server/Models/Slot.cs
@@ -12,5 +12,7 @@ namespace OfficeCafeApp.API.Models
 
         [Required]
         public TimeSpan EndTime { get; set; }
+
+        public int CurrentCount { get; set; }
     }
 }

--- a/Server/Services/AdminService.cs
+++ b/Server/Services/AdminService.cs
@@ -30,11 +30,12 @@ namespace OfficeCafeApp.API.Services
 
         public async Task<IEnumerable<(TimeSpan Slot, int Count)>> GetOrderCountsByDateAsync(DateTime date)
         {
-            return await _context.Orders
+            return (await _context.Orders
                 .Where(o => o.OrderDate.Date == date.Date)
                 .GroupBy(o => o.Slot.StartTime)
-                .Select(g => (Slot: g.Key, Count: g.Count()))
-                .ToListAsync();
+                .Select(g => new { Slot = g.Key, Count = g.Count() })
+                .ToListAsync())
+                .Select(g => (g.Slot, g.Count));
         }
 
         public async Task<bool> UpdateDishAvailabilityAsync(int dishId, bool isAvailable)

--- a/Server/Services/OrderService.cs
+++ b/Server/Services/OrderService.cs
@@ -32,7 +32,7 @@ namespace OfficeCafeApp.API.Services
                     UserId = userId,
                     SlotId = dto.SlotId,
                     QRCode = Guid.NewGuid().ToString(),
-                    Status = OrderStatus.Preparing
+                    Status = OrderStatus.Preparing.ToString()
                 };
                 _context.Orders.Add(order);
 
@@ -78,7 +78,7 @@ namespace OfficeCafeApp.API.Services
                 {
                     Id = o.Id,
                     OrderDate = o.OrderDate,
-                    Status = o.Status.ToString(),
+                    Status = o.Status,
                     QRCode = o.QRCode,
                     Slot = $"{o.Slot.StartTime:hh\\:mm}-{o.Slot.EndTime:hh\\:mm}",
                     Items = o.OrderItems.Select(oi => new OrderItemDto
@@ -104,7 +104,7 @@ namespace OfficeCafeApp.API.Services
             if ((slotStart - now).TotalMinutes < 30)
                 return new ServiceResult { Success = false, Error = "Too late to cancel." };
 
-            order.Status = OrderStatus.Cancelled;
+            order.Status = OrderStatus.Cancelled.ToString();
             slot.CurrentCount--;
             await _context.SaveChangesAsync();
             return new ServiceResult { Success = true };


### PR DESCRIPTION
## Summary
- fix tuple projection for async order counts
- store order status as string
- track slot order count

## Testing
- `dotnet build OfficeCafeApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aac30c84083219cc022adcc47a442