### PR TITLE
Fix admin module loading path

### DIFF
--- a/Server/wwwroot/admin/dashboard.html
+++ b/Server/wwwroot/admin/dashboard.html
@@ -84,7 +84,7 @@
 
             // 2) dynamically import the matching JS module
             try {
-                const module = await import(`./js/${page}.js`);
+                const module = await import(`../lib/js/${page}.js`);
                 console.log(`${page}.js loaded`, module);
                 module.init();
             } catch (err) {


### PR DESCRIPTION
## Summary
- correct module path for dashboard page so add dish popup works

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685142d68ae8832186fc4a3e8c106010