### PR TITLE
Fix missing portion size in edit modal

### DIFF
--- a/Server/wwwroot/lib/js/dishes.js
+++ b/Server/wwwroot/lib/js/dishes.js
@@ -116,9 +116,15 @@ const DishManager = (() => {
 
         if (d) {
             $("dishId").value = idOf(d);
-            $("name").value = d.name; $("portion").value = d.portion;
-            $("price").value = d.price; $("description").value = d.description || "";
-            if (d.imageUrl) { els.imgWrap.querySelector("img").src = d.imageUrl; els.imgWrap.classList.remove("hidden"); }
+            $("name").value = d.name;
+            $("portionSize").value = d.portionSize ?? d.PortionSize ?? "";
+            $("portion").value = d.portion;
+            $("price").value = d.price;
+            $("description").value = d.description || "";
+            if (d.imageUrl) {
+                els.imgWrap.querySelector("img").src = d.imageUrl;
+                els.imgWrap.classList.remove("hidden");
+            }
         }
 
         els.modal.classList.remove("hidden");


### PR DESCRIPTION
## Summary
- populate `portionSize` input when editing a dish

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68516e426bf08321a10fc8ffb3683391