### PR TITLE
Show portion size in admin dish list

### DIFF
--- a/Server/wwwroot/admin/Pages/dishes.html
+++ b/Server/wwwroot/admin/Pages/dishes.html
@@ -671,7 +671,7 @@
                     <i class="fas fa-${d.isAvailable ? 'check' : 'times'} mr-1 text-xs"></i>
                     ${d.isAvailable ? 'Available' : 'Disabled'}
                   </span>
-                  <span class="text-zinc-400"><i class="fas fa-weight-hanging mr-1 text-xs"></i>Portion: ${d.portion}</span>
+                  <span class="text-zinc-400"><i class="fas fa-weight-hanging mr-1 text-xs"></i>Portion: ${d.portionSize} ${d.portion}</span>
                   <span class="text-zinc-400"><i class="fas fa-fire mr-1 text-xs"></i>${d.orderCount || 0} orders</span>
                 </div>
                 <p class="text-zinc-300 mb-4">${d.description || 'No description.'}</p>

--- a/Server/wwwroot/lib/js/dishes.js
+++ b/Server/wwwroot/lib/js/dishes.js
@@ -94,7 +94,7 @@ const DishManager = (() => {
       <div class="flex flex-wrap items-center gap-3 text-sm mb-2">
         <span class="status-badge ${d.isAvailable ? 'status-available' : 'status-disabled'}">
           <i class="fas fa-${d.isAvailable ? 'check' : 'times'} mr-1 text-xs"></i>${d.isAvailable ? 'Available' : 'Disabled'}</span>
-        <span class="text-zinc-400"><i class="fas fa-weight-hanging mr-1 text-xs"></i>Portion: ${d.portion}</span>
+        <span class="text-zinc-400"><i class="fas fa-weight-hanging mr-1 text-xs"></i>Portion: ${d.portionSize} ${d.portion}</span>
       </div>
       <p class="text-zinc-300 mb-4">${d.description || "No description."}</p>
       <div class="flex flex-wrap gap-3 text-sm">


### PR DESCRIPTION
## Summary
- include portion size when listing dishes for editing

## Testing
- `dotnet build OfficeCafeApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516ffe0b808321af191f7cef5bc1d1