### PR TITLE
Fix dish update API handling

### DIFF
--- a/Server/wwwroot/lib/js/dishes.js
+++ b/Server/wwwroot/lib/js/dishes.js
@@ -9,7 +9,13 @@ const DishManager = (() => {
     const api = (url, opt = {}) => {
         const token = localStorage.getItem("token");
         return fetch(url, { ...opt, headers: { ...opt.headers, Authorization: `Bearer ${token}` } })
-            .then(async r => r.ok ? r.json() : Promise.reject(await r.json().catch(() => ({ status: r.status }))));
+            .then(async r => {
+                if (!r.ok) {
+                    throw await r.json().catch(() => ({ status: r.status }));
+                }
+                if (r.status === 204) return null;
+                return r.json();
+            });
     };
 
     /* ───────── state & cache ───────── */


### PR DESCRIPTION
## Summary
- handle 204 No Content responses in dishes.js `api` helper

## Testing
- `dotnet build OfficeCafeApp.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6851733047508321bd87393619687632